### PR TITLE
VEGA-210: Добавление описания в ПР не должно падать на ветках бота

### DIFF
--- a/.github/workflows/update-pr.yml
+++ b/.github/workflows/update-pr.yml
@@ -11,15 +11,14 @@ jobs:
       - uses: tzkhan/pr-update-action@v1.1.1
         with:
           repo-token: '${{ secrets.GITHUB_TOKEN }}'
-          branch-regex: 'VEGA-\d+'
+          branch-regex: '(VEGA-\d+)|(dependabot\S+)'
           title-template: ' '
           replace-title: false
           uppercase-title: true
           body-template: |
             ## Задача
-            Задача в Jira: https://jira.csssr.io/browse/%branch%
+            Задача в Jira CSSSR: https://jira.csssr.io/browse/%branch%
             Ссылка на стенд: https://%branch%.vega-2.csssr.cloud
-
           replace-body: false
-          body-prefix-newline-count: 1
+          body-prefix-newline-count: 2
           uppercase-body: true


### PR DESCRIPTION
Jira issue: VEGA-210

## Чек-лист

- [ ] Назначен исполнитель PR
- [ ] eslint/stylelint и dev-консоль браузера без ошибок
- [ ] Написаны тесты или заведена задача на покрытие тестами

## Дополнительно

- [ ] проверять все разрешения, когда меняется верстка
- [ ] Указан `no_test` лейбл в задаче, если не требуется тестирование QA
- [ ] В задаче описано, как тестировать изменения (если это нужно)
